### PR TITLE
feat: systemd service and deploy docs for web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,19 @@ sudo systemctl daemon-reload
 sudo systemctl enable --now sirencast-collector
 ```
 Adjust WorkingDirectory in the service file to your install path.
+
+## Web App
+
+### Dev server
+```bash
+uvicorn web.main:app --reload --port 8000
+```
+Open http://localhost:8000 in your browser.
+
+### Systemd (production)
+```bash
+sudo cp sirencast-web.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now sirencast-web
+```
+Adjust `WorkingDirectory` in the service file to match your install path.

--- a/sirencast-web.service
+++ b/sirencast-web.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=SirenCast Web App
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/sirencast
+ExecStart=/opt/sirencast/venv/bin/uvicorn web.main:app --host 0.0.0.0 --port 8000
+Restart=always
+RestartSec=5
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- Add `sirencast-web.service` for running the web app via systemd on the Pi
- Update README with dev server command and production deploy steps

## Test plan
- [ ] Service file syntax is valid (`systemd-analyze verify sirencast-web.service`)
- [ ] README contains dev and production instructions

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)