### PR TITLE
feat: show area summary stats when idle

### DIFF
--- a/web/db.py
+++ b/web/db.py
@@ -172,6 +172,52 @@ def get_incidents_for_area(area: str) -> list:
     return result
 
 
+def get_area_stats(area: str) -> dict:
+    """
+    Aggregate stats for a single area:
+    - total_incidents: how many incidents had this area in their cat=10 warning
+    - had_siren_incidents: how many of those had any siren at all
+    - area_siren_count: how many of those had a siren specifically for this area
+    - area_siren_pct: area_siren_count / total_incidents * 100
+    """
+    conn = get_connection()
+
+    # Incidents where this area appeared in any cat10_snapshot
+    inc_rows = conn.execute("""
+        SELECT DISTINCT i.id, i.had_siren
+        FROM incidents i
+        JOIN cat10_snapshots s ON s.incident_id = i.id
+        JOIN cat10_areas a ON a.snapshot_id = s.id
+        WHERE a.area = ?
+    """, [area]).fetchall()
+
+    total = len(inc_rows)
+    if total == 0:
+        conn.close()
+        return {'total_incidents': 0, 'had_siren_incidents': 0, 'area_siren_count': 0, 'area_siren_pct': 0.0}
+
+    had_siren = sum(1 for r in inc_rows if r['had_siren'])
+    siren_inc_ids = [r['id'] for r in inc_rows if r['had_siren']]
+
+    area_siren_count = 0
+    if siren_inc_ids:
+        ph = ','.join(['?' for _ in siren_inc_ids])
+        area_siren_count = conn.execute(f"""
+            SELECT COUNT(DISTINCT cal.incident_id)
+            FROM cat1_alerts cal
+            JOIN cat1_areas ca ON ca.alert_id = cal.id
+            WHERE ca.area = ? AND cal.incident_id IN ({ph})
+        """, [area] + siren_inc_ids).fetchone()[0]
+
+    conn.close()
+    return {
+        'total_incidents': total,
+        'had_siren_incidents': had_siren,
+        'area_siren_count': area_siren_count,
+        'area_siren_pct': round(area_siren_count / total * 100, 1) if total > 0 else 0.0,
+    }
+
+
 def get_all_known_areas() -> list:
     """Return sorted list of all distinct area strings seen in cat10_areas + cat1_areas."""
     conn = get_connection()

--- a/web/main.py
+++ b/web/main.py
@@ -26,6 +26,12 @@ def get_history(areas: str = Query('')):
     area_list = [a.strip() for a in areas.split(',') if a.strip()]
     return db.query_historical_counts(area_list)
 
+@app.get('/api/area-stats')
+def get_area_stats(area: str = Query('')):
+    if not area.strip():
+        return {'total_incidents': 0, 'had_siren_incidents': 0, 'area_siren_count': 0, 'area_siren_pct': 0.0}
+    return db.get_area_stats(area.strip())
+
 @app.get('/api/incidents')
 def get_incidents(area: str = Query('')):
     if not area.strip():

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -369,6 +369,7 @@ const headerSubtitle = document.getElementById('header-subtitle');
 const resultsDiv = document.getElementById('results');
 
 let lastAreasKey = '';
+let lastIdleArea = null;
 let pollErrors = 0;
 let lastPollTime = null;
 let allAreas = [];
@@ -458,10 +459,34 @@ function getProgressColor(pct) {
   return '#22c55e';
 }
 
-function renderIdle() {
+function renderIdle(areaStats) {
   statusDot.className = 'status-dot';
   headerSubtitle.textContent = '';
-  resultsDiv.innerHTML = '<div class="placeholder-text">אין התראה פעילה כרגע</div>';
+  if (!areaStats || areaStats.total_incidents === 0) {
+    const msg = areaStats ? 'האזור שנבחר לא הופיע באף אזהרה מתועדת' : 'אין התראה פעילה כרגע';
+    resultsDiv.innerHTML = `<div class="placeholder-text">${msg}</div>`;
+    return;
+  }
+  const s = areaStats;
+  const pct = s.area_siren_pct;
+  const color = pct > 50 ? '#ef4444' : pct > 20 ? '#f59e0b' : '#22c55e';
+  resultsDiv.innerHTML = `
+    <div class="summary-line" style="margin-bottom:16px;">סטטיסטיקות היסטוריות לאזור</div>
+    <div class="area-row">
+      <span class="area-name">הופיע באזהרה מוקדמת</span>
+      <span class="area-fraction" dir="ltr">${s.total_incidents}x</span>
+    </div>
+    <div class="area-row">
+      <span class="area-name">הסתיים באזעקה כלשהי</span>
+      <span class="area-fraction" dir="ltr">${s.had_siren_incidents}/${s.total_incidents}</span>
+    </div>
+    <div class="area-row" style="border-bottom:none;">
+      <span class="area-name" style="font-weight:600;">אזעקה באזור זה ספציפית</span>
+      <span class="area-fraction" dir="ltr" style="color:${color};font-weight:700;">${s.area_siren_count}/${s.total_incidents}</span>
+      <div class="progress-bar">
+        <div class="progress-fill" style="width:${pct}%;background:${color}"></div>
+      </div>
+    </div>`;
 }
 
 function renderCat10(areas, historyData) {
@@ -547,9 +572,20 @@ async function pollLive() {
 
     if (!data.active) {
       lastAreasKey = '';
-      renderIdle();
+      const userArea = getUserArea();
+      if (userArea !== lastIdleArea) {
+        lastIdleArea = userArea;
+        if (userArea) {
+          const statsRes = await fetch('/api/area-stats?area=' + encodeURIComponent(userArea));
+          const stats = await statsRes.json();
+          renderIdle(stats);
+        } else {
+          renderIdle(null);
+        }
+      }
       return;
     }
+    lastIdleArea = null;
 
     if (data.cat === '10') {
       const areasKey = data.areas.join(',');
@@ -655,10 +691,11 @@ async function loadHistory(area) {
   }
 }
 
-// Trigger history reload when area is selected
+// Trigger history + stats reload when area is selected
 const _origSelectArea = selectArea;
 selectArea = function(value) {
   _origSelectArea(value);
+  lastIdleArea = null; // force stats refresh on next poll
   loadHistory(value);
 };
 


### PR DESCRIPTION
Closes #28

When an area is selected and no alert is active, the main panel now shows aggregate historical stats for that area instead of just 'אין התראה פעילה כרגע':

- How many times the area appeared in a cat=10 advance warning
- How many of those incidents had any siren
- How many resulted in a siren specifically for this area (+ progress bar)

New: `GET /api/area-stats?area=<area>` endpoint + `get_area_stats()` in db.py
Stats are only re-fetched when the selected area changes (not every poll tick).