### PR TITLE
fix: distinguish siren-for-area vs siren-elsewhere in history

### DIFF
--- a/web/db.py
+++ b/web/db.py
@@ -138,6 +138,7 @@ def get_incidents_for_area(area: str) -> list:
             'had_siren': bool(inc['had_siren']),
             'cat10_areas': cat10_areas,
             'cat1_areas': cat1_areas,
+            'area_got_siren': None,  # filled in after area_siren_set is computed
         })
 
     # Sort ascending to compute rolling prediction
@@ -156,6 +157,10 @@ def get_incidents_for_area(area: str) -> list:
         """, [area] + siren_inc_ids).fetchall()
         area_siren_set = {r['incident_id'] for r in rows}
 
+    # Fill in area_got_siren now that we have area_siren_set
+    for item in result:
+        item['area_got_siren'] = item['id'] in area_siren_set
+
     # Rolling prediction: among prior incidents where this area was in cat10,
     # how many had a siren for this area specifically?
     running_total = 0
@@ -164,7 +169,7 @@ def get_incidents_for_area(area: str) -> list:
         item['prediction'] = {'count': running_siren, 'total': running_total}
         # Update counters for the NEXT incident
         running_total += 1
-        if item['id'] in area_siren_set:
+        if item['area_got_siren']:
             running_siren += 1
 
     result.sort(key=lambda x: x['started_at'], reverse=True)

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -300,6 +300,10 @@ body {
   background: #1a2e1a;
   color: #86efac;
 }
+.history-siren-badge.elsewhere {
+  background: #2d2000;
+  color: #fde68a;
+}
 .history-areas-count {
   font-size: 0.8rem;
   color: #666;
@@ -668,8 +672,8 @@ function renderHistory(incidents, selectedArea) {
   section.style.display = 'block';
   list.innerHTML = incidents.map((inc, idx) => {
     const dateStr = formatTs(inc.started_at);
-    const sirenClass = inc.had_siren ? 'yes' : 'no';
-    const sirenText = inc.had_siren ? '🚨 אזעקה' : '✅ ללא אזעקה';
+    const sirenClass = inc.area_got_siren ? 'yes' : (inc.had_siren ? 'elsewhere' : 'no');
+    const sirenText = inc.area_got_siren ? '🚨 אזעקה לאזור זה' : (inc.had_siren ? '⚠️ אזעקה — לא לאזור זה' : '✅ ללא אזעקה');
     const areasCount = `${inc.cat10_areas.length} אזורים`;
 
     const pred = inc.prediction;


### PR DESCRIPTION
Closes #34

Adds `area_got_siren` field to each incident returned by `/api/incidents`.

Three history badge states:
- ✅ ללא אזעקה (green) — no siren fired at all
- ⚠️ אזעקה — לא לאזור זה (yellow) — siren fired but for a different area
- 🚨 אזעקה לאזור זה (red) — siren fired specifically for the selected area

Fixes the confusion where Tel Aviv showed '🚨 אזעקה' for an incident where the siren actually hit the North (Galilee), making the 0/4 stat look wrong.