### PR TITLE
fix: simplify history badge to 2 states

### DIFF
--- a/web/static/index.html
+++ b/web/static/index.html
@@ -309,10 +309,7 @@ body {
   background: #1a2e1a;
   color: #86efac;
 }
-.history-siren-badge.elsewhere {
-  background: #2d2000;
-  color: #fde68a;
-}
+
 .history-areas-count {
   font-size: 0.8rem;
   color: #666;
@@ -682,8 +679,8 @@ function renderHistory(incidents, selectedArea) {
   section.style.display = 'block';
   list.innerHTML = incidents.map((inc, idx) => {
     const dateStr = formatTs(inc.started_at);
-    const sirenClass = inc.area_got_siren ? 'yes' : (inc.had_siren ? 'elsewhere' : 'no');
-    const sirenText = inc.area_got_siren ? '🚨 אזעקה לאזור זה' : (inc.had_siren ? '⚠️ אזעקה — לא לאזור זה' : '✅ ללא אזעקה');
+    const sirenClass = inc.area_got_siren ? 'yes' : 'no';
+    const sirenText = inc.area_got_siren ? '🚨 אזעקה' : '✅ ללא אזעקה';
     const areasCount = `${inc.cat10_areas.length} אזורים`;
 
     const pred = inc.prediction;


### PR DESCRIPTION
The 3-state badge (siren / siren elsewhere / no siren) was confusing. From the selected area's perspective, only one thing matters: did MY area get a siren?

Now: ✅ ללא אזעקה / 🚨 אזעקה — based purely on area_got_siren. The 'elsewhere' state is removed.