### PR TITLE
fix: area always visible in its own history + clearer badge

### DIFF
--- a/web/db.py
+++ b/web/db.py
@@ -120,7 +120,23 @@ def get_incidents_for_area(area: str) -> list:
         if not inc:
             continue
 
-        cat10_areas = _get_canonical_cat10_areas(conn, inc_id)
+        # Use the FIRST snapshot where this area appeared (not the last).
+        # Warnings narrow over time — the selected area may be dropped from
+        # later snapshots, making it invisible in its own history row.
+        first_snap = conn.execute("""
+            SELECT s.id FROM cat10_snapshots s
+            JOIN cat10_areas a ON a.snapshot_id = s.id
+            WHERE s.incident_id = ? AND a.area = ?
+            ORDER BY s.id ASC LIMIT 1
+        """, [inc_id, area]).fetchone()
+
+        cat10_areas = []
+        if first_snap:
+            rows = conn.execute(
+                'SELECT area FROM cat10_areas WHERE snapshot_id = ? ORDER BY area',
+                [first_snap['id']]
+            ).fetchall()
+            cat10_areas = [r['area'] for r in rows]
 
         cat1_areas = []
         if inc['had_siren']:

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -680,7 +680,7 @@ function renderHistory(incidents, selectedArea) {
   list.innerHTML = incidents.map((inc, idx) => {
     const dateStr = formatTs(inc.started_at);
     const sirenClass = inc.area_got_siren ? 'yes' : 'no';
-    const sirenText = inc.area_got_siren ? '🚨 אזעקה' : '✅ ללא אזעקה';
+    const sirenText = inc.area_got_siren ? '🚨 אזעקה לאזור זה' : '✅ ללא אזעקה לאזור זה';
     const areasCount = `${inc.cat10_areas.length} אזורים`;
 
     const pred = inc.prediction;


### PR DESCRIPTION
Closes #39

**Fix 1 — area in its own list**: Changed from last snapshot to FIRST snapshot that contains the selected area. Warnings narrow over time, so the area may be dropped from later snapshots. Using the first snapshot guarantees the area is always visible in the expanded detail.

**Fix 2 — badge label**: '✅ ללא אזעקה' → '✅ ללא אזעקה לאזור זה' and '🚨 אזעקה' → '🚨 אזעקה לאזור זה' — makes clear the badge is area-specific.