### PR TITLE
fix: cat10 union across all snapshots + clearer empty cat1 message

### DIFF
--- a/web/db.py
+++ b/web/db.py
@@ -120,23 +120,17 @@ def get_incidents_for_area(area: str) -> list:
         if not inc:
             continue
 
-        # Use the FIRST snapshot where this area appeared (not the last).
-        # Warnings narrow over time — the selected area may be dropped from
-        # later snapshots, making it invisible in its own history row.
-        first_snap = conn.execute("""
-            SELECT s.id FROM cat10_snapshots s
-            JOIN cat10_areas a ON a.snapshot_id = s.id
-            WHERE s.incident_id = ? AND a.area = ?
-            ORDER BY s.id ASC LIMIT 1
-        """, [inc_id, area]).fetchone()
-
-        cat10_areas = []
-        if first_snap:
-            rows = conn.execute(
-                'SELECT area FROM cat10_areas WHERE snapshot_id = ? ORDER BY area',
-                [first_snap['id']]
-            ).fetchall()
-            cat10_areas = [r['area'] for r in rows]
+        # Union of ALL areas across ALL cat10 snapshots for this incident.
+        # Warnings narrow over time, so the selected area may disappear from
+        # later snapshots. The union gives the complete accumulated picture.
+        rows = conn.execute("""
+            SELECT DISTINCT a.area
+            FROM cat10_areas a
+            JOIN cat10_snapshots s ON s.id = a.snapshot_id
+            WHERE s.incident_id = ?
+            ORDER BY a.area
+        """, [inc_id]).fetchall()
+        cat10_areas = [r['area'] for r in rows]
 
         cat1_areas = []
         if inc['had_siren']:

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -698,12 +698,12 @@ function renderHistory(incidents, selectedArea) {
       return `<span class="history-area-tag ${cls}">${a}</span>`;
     }).join('');
 
-    const cat1Tags = inc.had_siren
+    const cat1Tags = inc.cat1_areas.length > 0
       ? inc.cat1_areas.map(a => {
           const cls = a === selectedArea ? 'selected' : 'siren';
           return `<span class="history-area-tag ${cls}">${a}</span>`;
         }).join('')
-      : '<span style="color:#555;font-size:0.8rem;">—</span>';
+      : '<span style="color:#555;font-size:0.82rem;">הcollector לא תיעד אזעקות לאירוע זה</span>';
 
     return `
       <div class="history-item" id="hinc-${idx}">


### PR DESCRIPTION
Closes #41

1. cat10_areas now shows DISTINCT union across ALL snapshots for the incident — gives the complete accumulated warning area picture, and guarantees the selected area is always included.
2. Empty cat1_areas shows 'הcollector לא תיעד אזעקות לאירוע זה' instead of '—'