### PR TITLE
feat: /api/locate — exact oref area from GPS using tzevaadom cities.json

### DIFF
--- a/web/main.py
+++ b/web/main.py
@@ -1,14 +1,54 @@
 import json
 import logging
+import math
+import os
+import httpx
 from fastapi import FastAPI, Query
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import FileResponse
-import httpx
 
 from web import db
+from collector import config
 
 logger = logging.getLogger(__name__)
 app = FastAPI(title='SirenCast')
+
+CITIES_URL = 'https://www.tzevaadom.co.il/static/cities.json'
+cities_cache: dict = {}  # name -> {lat, lng}
+
+def haversine_km(lat1, lng1, lat2, lng2) -> float:
+    R = 6371.0
+    dlat = math.radians(lat2 - lat1)
+    dlng = math.radians(lng2 - lng1)
+    a = math.sin(dlat / 2) ** 2 + math.cos(math.radians(lat1)) * math.cos(math.radians(lat2)) * math.sin(dlng / 2) ** 2
+    return R * 2 * math.asin(math.sqrt(a))
+
+async def load_cities():
+    global cities_cache
+    # Try local file first (data/cities.json), then fetch from tzevaadom
+    local_path = os.path.join(config.DATA_DIR, 'cities.json')
+    try:
+        if os.path.exists(local_path):
+            with open(local_path, encoding='utf-8') as f:
+                data = json.load(f)
+        else:
+            async with httpx.AsyncClient() as client:
+                r = await client.get(CITIES_URL, headers={'User-Agent': 'SirenCast/1.0'}, timeout=10)
+            data = r.json()
+            with open(local_path, 'w', encoding='utf-8') as f:
+                json.dump(data, f, ensure_ascii=False)
+        cities_cache = {
+            name: {'lat': c['lat'], 'lng': c['lng']}
+            for name, c in data.get('cities', {}).items()
+            if 'lat' in c and 'lng' in c
+        }
+        logger.info(f'Loaded {len(cities_cache)} cities for location lookup')
+    except Exception as e:
+        logger.warning(f'Failed to load cities data: {e}')
+
+@app.on_event('startup')
+async def startup():
+    await load_cities()
 
 OREF_URL = 'https://www.oref.org.il/warningMessages/alert/alerts.json'
 OREF_HEADERS = {
@@ -25,6 +65,18 @@ def list_areas():
 def get_history(areas: str = Query('')):
     area_list = [a.strip() for a in areas.split(',') if a.strip()]
     return db.query_historical_counts(area_list)
+
+@app.get('/api/locate')
+def locate(lat: float = Query(...), lng: float = Query(...)):
+    if not cities_cache:
+        return {'area': None, 'distance_km': None}
+    best_name, best_dist = None, float('inf')
+    for name, c in cities_cache.items():
+        d = haversine_km(lat, lng, c['lat'], c['lng'])
+        if d < best_dist:
+            best_dist = d
+            best_name = name
+    return {'area': best_name, 'distance_km': round(best_dist, 2)}
 
 @app.get('/api/area-stats')
 def get_area_stats(area: str = Query('')):

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -690,29 +690,12 @@ async function pollLive() {
 }
 
 // ── Geolocation ──────────────────────────────────────────
-function matchCityToAreas(cityName) {
-  if (!cityName || !allAreas.length) return [];
-  // Normalize: strip "-X" suffix (e.g. "תל אביב-יפו" → "תל אביב")
-  const norm = cityName.split('-')[0].split('–')[0].trim();
-  return allAreas.filter(a => {
-    const base = a.includes(' - ') ? a.split(' - ')[0].trim() : a.trim();
-    return base === norm || base.includes(norm) || norm.includes(base);
-  });
-}
-
 async function resolveLocation(lat, lng) {
-  const url = `https://nominatim.openstreetmap.org/reverse?lat=${lat}&lon=${lng}&format=json&accept-language=he`;
-  const res = await fetch(url, { headers: { 'User-Agent': 'SirenCast/1.0' } });
+  // Uses our backend /api/locate which does nearest-city lookup
+  // against tzevaadom's cities.json (1449 exact oref area names + lat/lng)
+  const res = await fetch(`/api/locate?lat=${lat}&lng=${lng}`);
   const data = await res.json();
-  const addr = data.address || {};
-  // Try from most specific to least
-  for (const key of ['suburb', 'neighbourhood', 'quarter', 'city_district', 'city', 'town', 'village']) {
-    if (addr[key]) {
-      const matches = matchCityToAreas(addr[key]);
-      if (matches.length > 0) return { city: addr[key], matches };
-    }
-  }
-  return { city: addr.city || addr.town || '', matches: [] };
+  return data.area || null;  // exact oref area name, or null
 }
 
 async function locateMe() {
@@ -727,21 +710,11 @@ async function locateMe() {
 
   navigator.geolocation.getCurrentPosition(async (pos) => {
     try {
-      const { city, matches } = await resolveLocation(pos.coords.latitude, pos.coords.longitude);
+      const area = await resolveLocation(pos.coords.latitude, pos.coords.longitude);
       btn.classList.remove('locating');
-
-      if (matches.length === 1) {
-        selectArea(matches[0]);
+      if (area) {
+        selectArea(area);
         btn.classList.add('located');
-        btn.textContent = '📍';
-      } else if (matches.length > 1) {
-        // Pre-filter dropdown to matching areas
-        areaInput.removeAttribute('readonly');
-        areaInput.value = city.split('-')[0].trim();
-        renderDropdown(areaInput.value);
-        dropdownList.classList.add('open');
-        areaInput.focus();
-        btn.textContent = '📍';
       } else {
         btn.textContent = '❓';
         setTimeout(() => { btn.textContent = '📍'; }, 3000);
@@ -759,14 +732,13 @@ async function locateMe() {
 }
 
 async function autoLocate() {
-  // Auto-locate only if no area is already saved
   if (getUserArea() || !navigator.geolocation) return;
   navigator.geolocation.getCurrentPosition(async (pos) => {
     try {
-      if (getUserArea()) return; // user selected manually in the meantime
-      const { matches } = await resolveLocation(pos.coords.latitude, pos.coords.longitude);
-      if (matches.length === 1 && !getUserArea()) {
-        selectArea(matches[0]);
+      if (getUserArea()) return;
+      const area = await resolveLocation(pos.coords.latitude, pos.coords.longitude);
+      if (area && !getUserArea()) {
+        selectArea(area);
         document.getElementById('locate-btn').classList.add('located');
       }
     } catch (_) {}


### PR DESCRIPTION
Replaces the nominatim fuzzy-match approach with a precise nearest-city lookup.

**How it works:**
1. tzevaadom's `cities.json` contains 1,449 exact oref area names each with lat/lng coordinates
2. Backend loads it at startup (from local `data/cities.json`, or fetches + caches on first run)
3. `GET /api/locate?lat=X&lng=Y` returns the nearest city name by Haversine distance
4. That name is the exact oref area string — no fuzzy matching needed

**Test results:**
- Tel Aviv center (32.08, 34.78) → 'תל אביב - מרכז העיר' (0.26km)
- Beer Sheva (31.25, 34.79) → 'באר שבע - מערב' (1.6km)

Frontend now calls `/api/locate` instead of nominatim. Single guaranteed match → auto-select.