### PR TITLE
feat: dual prediction badges in history — general + profile

### DIFF
--- a/web/db.py
+++ b/web/db.py
@@ -171,16 +171,43 @@ def get_incidents_for_area(area: str) -> list:
     for item in result:
         item['area_got_siren'] = item['id'] in area_siren_set
 
-    # Rolling prediction: among prior incidents where this area was in cat10,
-    # how many had a siren for this area specifically?
+    # General prediction (rolling): among prior incidents where this area was
+    # in ANY cat10 warning, how many had a siren for this area?
     running_total = 0
     running_siren = 0
     for item in result:
-        item['prediction'] = {'count': running_siren, 'total': running_total}
-        # Update counters for the NEXT incident
+        item['prediction_general'] = {'count': running_siren, 'total': running_total}
         running_total += 1
         if item['area_got_siren']:
             running_siren += 1
+
+    # Profile prediction (exact match): among prior incidents with the SAME
+    # canonical (last-snapshot) cat10 area set, how many had a siren for this area?
+    # Build registry: all incidents → (started_at, canonical_set)
+    all_inc_rows = conn.execute('SELECT id, started_at FROM incidents').fetchall()
+    registry = {}  # incident_id -> (started_at, frozenset)
+    for row in all_inc_rows:
+        canonical = _get_canonical_cat10_areas(conn, row['id'])
+        registry[row['id']] = (row['started_at'], frozenset(canonical))
+
+    for item in result:
+        item_ts = item['started_at']
+        item_canonical = frozenset(_get_canonical_cat10_areas(conn, item['id']))
+        prior_ids = [
+            iid for iid, (ts, aset) in registry.items()
+            if iid != item['id'] and aset == item_canonical and ts < item_ts
+        ]
+        if prior_ids:
+            ph = ','.join(['?' for _ in prior_ids])
+            siren_count = conn.execute(f"""
+                SELECT COUNT(DISTINCT cal.incident_id)
+                FROM cat1_alerts cal
+                JOIN cat1_areas ca ON ca.alert_id = cal.id
+                WHERE ca.area = ? AND cal.incident_id IN ({ph})
+            """, [area] + prior_ids).fetchone()[0]
+        else:
+            siren_count = 0
+        item['prediction_profile'] = {'count': siren_count, 'total': len(prior_ids)}
 
     result.sort(key=lambda x: x['started_at'], reverse=True)
     conn.close()

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -409,6 +409,18 @@ body {
   border: 1px solid #f59e0b;
   color: #fde68a;
 }
+/* Prediction badge groups */
+.pred-group {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1px;
+}
+.pred-label {
+  font-size: 0.6rem;
+  color: #555;
+  white-space: nowrap;
+}
 /* Prediction badge */
 .pred-badge {
   font-size: 0.78rem;
@@ -808,15 +820,15 @@ function renderHistory(incidents, selectedArea) {
     const sirenText = inc.area_got_siren ? '🚨 אזעקה לאזור זה' : '✅ ללא אזעקה לאזור זה';
     const areasCount = `${inc.cat10_areas.length} אזורים`;
 
-    const pred = inc.prediction;
-    let predHtml = '';
-    if (pred.total === 0) {
-      predHtml = `<span class="pred-badge pred-unknown" title="אין נתונים היסטוריים קודמים">—</span>`;
-    } else {
+    function makePredBadge(pred, title) {
+      if (pred.total === 0)
+        return `<span class="pred-badge pred-unknown" title="${title}">—</span>`;
       const pct = Math.round(pred.count / pred.total * 100);
-      const predClass = pct > 50 ? 'pred-high' : pct > 20 ? 'pred-mid' : 'pred-low';
-      predHtml = `<span class="pred-badge ${predClass}" title="הסיכוי שחושב בזמן האזהרה">${pred.count}/${pred.total}</span>`;
+      const cls = pct > 50 ? 'pred-high' : pct > 20 ? 'pred-mid' : 'pred-low';
+      return `<span class="pred-badge ${cls}" title="${title}">${pred.count}/${pred.total}</span>`;
     }
+    const predGeneralHtml = makePredBadge(inc.prediction_general, 'כלל אזהרות שכללו אזור זה');
+    const predProfileHtml = makePredBadge(inc.prediction_profile, 'אזהרות עם אותו פרופיל מדויק (כמו בתצוגה החיה)');
 
     const cat10Tags = inc.cat10_areas.map(a => {
       const cls = a === selectedArea ? 'selected' : '';
@@ -836,7 +848,12 @@ function renderHistory(incidents, selectedArea) {
           <div class="history-header-row1">
             <span class="history-chevron">▼</span>
             <span class="history-siren-badge ${sirenClass}">${sirenText}</span>
-            ${predHtml}
+            <span class="pred-group">
+              <span class="pred-label">כללי</span>${predGeneralHtml}
+            </span>
+            <span class="pred-group">
+              <span class="pred-label">פרופיל</span>${predProfileHtml}
+            </span>
           </div>
           <div class="history-header-row2">
             <span class="history-date" dir="ltr">${dateStr}</span>


### PR DESCRIPTION
Closes #51

Each history row now shows two prediction badges:

**כללי (General)**: rolling count — among all prior warnings that included this area, X/Y resulted in a siren here. Always has data.

**פרופיל (Profile)**: exact match — among prior warnings with the identical last-snapshot cat=10 area set, X/Y resulted in a siren here. Same logic as the live view. May show — until enough data accumulates.

Backend: added `prediction_profile` field (exact canonical-set match with prior incidents) alongside renamed `prediction_general` in `get_incidents_for_area()`.